### PR TITLE
Move prices into tokens

### DIFF
--- a/app/gauges/model.py
+++ b/app/gauges/model.py
@@ -31,6 +31,7 @@ class Gauge(Model):
     # Total Bribes Value
     tbv = FloatField(default=0.0)
     # Voting APR
+    votes = FloatField(default=0.0)
     apr = FloatField(default=0.0)
 
     # TODO: Backwards compat. Remove once no longer needed...
@@ -131,6 +132,7 @@ class Gauge(Model):
         votes = votes / 10**token.decimals
 
         if votes * token.price > 0:
+            gauge.votes = votes
             gauge.apr = ((gauge.tbv * 52) / (votes * token.price)) * 100
             gauge.save()
 

--- a/app/gauges/model.py
+++ b/app/gauges/model.py
@@ -128,11 +128,10 @@ class Gauge(Model):
         )()
 
         token = Token.find(DEFAULT_TOKEN_ADDRESS)
-        price = token.aggregated_price_in_stables()
         votes = votes / 10**token.decimals
 
-        if votes * price > 0:
-            gauge.apr = ((gauge.tbv * 52) / (votes * price)) * 100
+        if votes * token.price > 0:
+            gauge.apr = ((gauge.tbv * 52) / (votes * token.price)) * 100
             gauge.save()
 
     @classmethod
@@ -167,12 +166,7 @@ class Gauge(Model):
 
             gauge.rewards[token.address] = amount / 10**token.decimals
 
-            token_price = token.aggregated_price_in_stables()
-
-            if token_price == 0:
-                token_price = token.chain_price_in_stables()
-
-            gauge.tbv += amount / 10**token.decimals * token_price
+            gauge.tbv += amount / 10**token.decimals * token.price
 
             LOGGER.debug(
                 'Fetched %s:%s reward %s:%s.',
@@ -222,12 +216,7 @@ class Gauge(Model):
             elif fee > 0:
                 gauge.rewards[token_address] = fee / 10**token.decimals
 
-            token_price = token.aggregated_price_in_stables()
-
-            if token_price == 0:
-                token_price = token.chain_price_in_stables()
-
-            gauge.tbv += fee / 10**token.decimals * token_price
+            gauge.tbv += fee / 10**token.decimals * token.price
 
             LOGGER.debug(
                 'Fetched %s:%s reward %s:%s.',

--- a/app/pairs/model.py
+++ b/app/pairs/model.py
@@ -163,22 +163,15 @@ class Pair(Model):
     @classmethod
     def _tvl(cls, pool_data, token0, token1):
         """Returns the TVL of the pool."""
-        token0_price = token0.aggregated_price_in_stables()
-        token1_price = token1.aggregated_price_in_stables()
-
-        if token0_price == 0:
-            token0_price = token0.chain_price_in_stables()
-        if token1_price == 0:
-            token1_price = token1.chain_price_in_stables()
         tvl = 0
 
-        if token0_price != 0:
-            tvl += pool_data['reserve0'] * token0_price
+        if token0.price != 0:
+            tvl += pool_data['reserve0'] * token0.price
 
-        if token1_price != 0:
-            tvl += pool_data['reserve1'] * token1_price
+        if token1.price != 0:
+            tvl += pool_data['reserve1'] * token1.price
 
-        if tvl != 0 and (token0_price == 0 or token1_price == 0):
+        if tvl != 0 and (token0.price == 0 or token1.price == 0):
             tvl = tvl * 2
 
         return tvl

--- a/app/pairs/syncer.py
+++ b/app/pairs/syncer.py
@@ -19,7 +19,7 @@ def sync(force_shutdown=False):
 
     Token.from_tokenlists()
 
-    with ThreadPool() as pool:
+    with ThreadPool(4) as pool:
         addresses = Pair.chain_addresses()
 
         LOGGER.debug(

--- a/app/tests/assets_test.py
+++ b/app/tests/assets_test.py
@@ -13,8 +13,13 @@ class AssetsTestCase(AppTestCase):
         self.assertEqual(type(result.json['data']), list)
         self.assertTrue(len(result.json['data']) > 1)
 
-        for ignored in IGNORED_TOKEN_ADDRESSES:
-            self.assertEqual(
-                len(list(Token.query(Token.address == ignored))),
-                0
-            )
+        ignored = list(
+            filter(lambda t: t.address in IGNORED_TOKEN_ADDRESSES, Token.all())
+        )
+
+        self.assertEqual(len(ignored), 0)
+
+        zero_priced = list(filter(lambda t: t.price == 0, Token.all()))
+        zero_priced_symbols = list(map(lambda t: t.symbol, zero_priced))
+
+        self.assertFalse('BOND' in zero_priced_symbols)


### PR DESCRIPTION
Some changes that should reduce the hits on our vendors for price data.

As well as cached price and gauge votes should be available in the API now.

/cc @velodrome-finance/api 