### PR TITLE
Configuration cache

### DIFF
--- a/app/configuration/__init__.py
+++ b/app/configuration/__init__.py
@@ -6,24 +6,24 @@ import falcon
 from versiontools import Version
 
 from app import __version__
-from app.pairs import Pair, Token
+from app.pairs import Token
 from app.settings import CACHE, DEFAULT_TOKEN_ADDRESS, STABLE_TOKEN_ADDRESS,\
-    ROUTE_TOKEN_ADDRESSES
+    ROUTE_TOKEN_ADDRESSES, LOGGER
 
 
 class Configuration(object):
-    """Returns a app configuration object"""
+    """Handles app configuration"""
 
-    def on_get(self, req, resp):
+    CACHE_KEY = 'configuration:json'
+
+    @classmethod
+    def recache(cls):
         default_token = Token.find(DEFAULT_TOKEN_ADDRESS)
         stable_token = Token.find(STABLE_TOKEN_ADDRESS)
         route_tokens = [Token.find(token) for token in ROUTE_TOKEN_ADDRESSES]
         route_token_data = [token._data for token in route_tokens]
-        tvl = sum(map(lambda p: (p.tvl or 0), Pair.all()))
-        max_apr = max(map(lambda p: (p.apr or 0), Pair.all()))
 
-        resp.status = falcon.HTTP_200
-        resp.text = json.dumps(
+        conf = json.dumps(
             dict(
                 data=[
                     default_token._data,
@@ -31,12 +31,21 @@ class Configuration(object):
                     *route_token_data
                 ],
                 meta=dict(
-                    tvl=tvl,
-                    max_apr=max_apr,
                     default_token=default_token._data,
                     stable_token=stable_token._data,
-                    cache=(CACHE.connection is not None),
                     version=str(Version(*__version__))
                 )
             )
         )
+
+        CACHE.set(cls.CACHE_KEY, conf)
+        LOGGER.debug('Cache updated for %s.', cls.CACHE_KEY)
+
+        return conf
+
+    def on_get(self, req, resp):
+        """Caches and returns our configuration data"""
+        conf = CACHE.get(self.CACHE_KEY) or Configuration.recache()
+
+        resp.text = conf
+        resp.status = falcon.HTTP_200

--- a/app/pairs/syncer.py
+++ b/app/pairs/syncer.py
@@ -18,6 +18,8 @@ def sync():
     t0 = time.time()
 
     Token.from_tokenlists()
+    Assets.recache()
+    LOGGER.info('Syncing tokens done in %s seconds.', time.time() - t0)
 
     with ThreadPool(int(os.getenv('SYNC_MAX_THREADS', 4))) as pool:
         addresses = Pair.chain_addresses()
@@ -32,10 +34,7 @@ def sync():
         pool.close()
         pool.join()
 
-    # Reset any cache...
     Pairs.recache()
-    Assets.recache()
-
     LOGGER.info('Syncing pairs done in %s seconds.', time.time() - t0)
 
 

--- a/app/tests/configuration_test.py
+++ b/app/tests/configuration_test.py
@@ -7,7 +7,5 @@ class ConfigurationTestCase(AppTestCase):
     def test_get(self):
         result = self.simulate_get('/api/v1/configuration')
 
-        self.assertTrue(result.json['meta']['tvl'] > 0)
-        self.assertTrue(result.json['meta']['max_apr'] > 0)
+        self.assertTrue(len(result.json['data']) > 0)
         self.assertIsNotNone(result.json['meta']['version'])
-        self.assertFalse(result.json['meta']['cache'])


### PR DESCRIPTION
Configuration endpoint should no longer take 3s. It's also cached now

Affected endpoints:
 * `/api/v1/configuration`
 * `/api/v1/routeAssets`


/cc @velodrome-finance/api 